### PR TITLE
Makefile: fix RM function - trival

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ QTCURVE_DIR = $(DESTDIR)/usr/share/QtCurve/
 YAKUAKE_DIR = $(DESTDIR)/usr/share/yakuake/skins/
 INSTALL = install -d
 CP = cp -rf
-RM = -rm -rf
+RM = rm -rf
 
 all:
 


### PR DESCRIPTION
@varlesh

Infact some Makefile files using minus mark before remove commands, but here is not needed at all.